### PR TITLE
Move index increment operation to avoid array out-of-bounds

### DIFF
--- a/src/main/java/bot/LookupCommands.java
+++ b/src/main/java/bot/LookupCommands.java
@@ -310,8 +310,8 @@ implements CommandExecutor{
 		int index = 0;
 		boolean hasEnding = isImage(url + endings[index] + ".png?raw=true");
 
-		while(!hasEnding && index < endings.length){
-			hasEnding = isImage(url + endings[++index] + ".png?raw=true");
+		while(!hasEnding && ++index < endings.length){
+			hasEnding = isImage(url + endings[index] + ".png?raw=true");
 		}
 		if(hasEnding)
 			return endings[index] + ".png?raw=true";


### PR DESCRIPTION
Noticed this in the stacktraces you sent.