### PR TITLE
Fix image names for unquoted datafiles

### DIFF
--- a/src/main/java/bot/LookupCommands.java
+++ b/src/main/java/bot/LookupCommands.java
@@ -331,16 +331,16 @@ implements CommandExecutor{
 
 	// Returns the bare image name without quotes, or a nullstring if no image.
 	public static String GetImageName(String text){
-		int start = 0, end = 0;
-		if(text.contains("thumbnail")){
+		int start = 0;
+		if(text.contains("thumbnail"))
 			start = text.indexOf("thumbnail") + 10;
-			end = text.indexOf('\n', start) - 1;
-		}
-		else if(text.contains("sprite")){
+		else if(text.contains("sprite"))
 			start = text.indexOf("sprite") + 7;
-			end = text.indexOf('\n', start) - 1;
-		}
+		else
+			return "";
 
+		int end = text.indexOf('\n', start);
+		
 		return text.substring(start, end).replace("\"", "");
 	}
 }


### PR DESCRIPTION
String.substring will return a string of length end-start, from index 'start' to index 'end-1'. This means that for sprite "ship/image", the previous end-1 behavior was not needed to trim off the newline separator, and would actually strip off the closing ". However, if there is no closing ", this would strip off the last character of the name (e.g. sprite ship/archon -> ship/archo)

The `replace` operator is greedy, and should match both the starting and ending " to replace them.