### PR TITLE
Report bot version via -info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ james.sh
 hs_err_pid*
 /.idea
 /src/main/main.iml
+*_version.txt
+branch_name.txt

--- a/README.md
+++ b/README.md
@@ -7,27 +7,30 @@ Meet James, the Discord Bot made specifically for the Endless Sky Server.
 ### Requirements
 - A JDK (recommended Java 8 or better)
 - gradle on Linux, on Ẃindows use depr_gradlw.bat instead
+- Python 2.7+ and the [requests module](http://docs.python-requests.org/en/master/)
 ### Setup
-- Clone this repository (or your own Fork)
-- Using the Discord API, make a new Bot and save the "bot token" as token.txt in James' top-level directory (follow [this guide](https://github.com/DV8FromTheWorld/JDA/wiki/3%29-Getting-Started) until "2. Setup JDA Project")
-- Start James by executing `gradle run` or `depr_gradlew run`
+1. Clone or fork this repository
+2. Using the Discord API, make a new Bot and save the "bot token" as token.txt in James' top-level directory (follow [this guide](https://github.com/DV8FromTheWorld/JDA/wiki/3%29-Getting-Started) until "2. Setup JDA Project")
+3. Replace the 'HOST_RAW_URL' and 'HOST_PUBLIC_URL' and 'CONTENT_URL' strings with relevant URL destinations.
+4. Start James by executing `gradle run` or `depr_gradlew run`
 
 ## Features
-- Puts out Parts of the ES data files (Ships & Ship Variants, Outfits, Sprites/Thumbnails)
-- Links to PRs, commits and issues of the ES repository
-- Plays Music using lavaplayer
-- Corrects Incorrect Spelling of common ES related terms
-- Posts Server/Game related Memes
+- Displays portions of the Endless Sky data files (Ships & their variants, Outfits, Sprites/Thumbnails, Missions)
+- Links to PRs, commits and issues of the Endless Sky repository
+- Plays music using [lavaplayer](https://github.com/sedmelluq/lavaplayer)
+- Performs text corrections based on the contents of '/data/spellErrors.txt'
+- Posts both text- and image-based memes (limited to those defined in /data/)
 - Basic Moderation Commands (currently only message purging, but more to come)
 - Reacts when Members join/leave/get banned and gives them the merchant role, if necessary (not in stable yet)
 
 ## Credit
 Original Creator: @Wrzlprnft
 
-Original Maintainer/Hoster: @Nechochwen-D
+Original Maintainer / Hoster: @Nechochwen-D
 
-Current Maintainer/Hoster: @MCOfficer
+Current Maintainer / Hoster: @MCOfficer
 
-Main Contributer/PR Bot: @tehhowch
+Contributors / PR Bots:
+ - @tehhowch
 
 24/7 Development Support: @MinnDevelopment and the JDA Discord Server

--- a/build.gradle
+++ b/build.gradle
@@ -9,21 +9,38 @@ targetCompatibility = 1.8
 ext.logbackVersion = '1.1.8'
 
 repositories {
-    jcenter()
-	maven{
+	jcenter()
+	maven {
 		url "http://repo.bastian-oppermann.de"
 	}
 }
 
 dependencies {
 	compile group: 'org.kohsuke', name: 'github-api', version: '1.85'
-     compile 'com.sedmelluq:lavaplayer:1.2.34'
-	 compile 'net.dv8tion:JDA:3.2.0_227'
-	 compile 'de.btobastian.sdcf4j:sdcf4j-core:1.0.4'
-	 compile 'de.btobastian.sdcf4j:sdcf4j-jda3:1.0.4'
-	 compile 'junit:junit:4.12'
-	 runtime "ch.qos.logback:logback-classic:$logbackVersion"
-	 runtime "ch.qos.logback:logback-core:$logbackVersion"
+	compile 'com.sedmelluq:lavaplayer:1.2.34'
+	compile 'net.dv8tion:JDA:3.2.0_227'
+	compile 'de.btobastian.sdcf4j:sdcf4j-core:1.0.4'
+	compile 'de.btobastian.sdcf4j:sdcf4j-jda3:1.0.4'
+	compile 'junit:junit:4.12'
+	runtime "ch.qos.logback:logback-classic:$logbackVersion"
+	runtime "ch.qos.logback:logback-core:$logbackVersion"
+}
+
+task writeVersion(type: Exec) {
+	executable "bash"
+	args "./scripts/version_logger.sh"
+}
+task writeBranch(type: Exec) {
+	executable "bash"
+	args "./scripts/branch_writer.sh"
+}
+task updateData(type: Exec) {
+	executable "python"
+	args "./scripts/updateFileNames.py"
+}
+
+run.dependsOn {
+	tasks.withType(Exec)
 }
 
 test {

--- a/scripts/branch_writer.sh
+++ b/scripts/branch_writer.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get the currently checked-out branch and write to a file
+branchName=$(git rev-parse --abbrev-ref HEAD)
+hasName=$?
+
+if [ "$hasName" == 0 ]; then
+	echo "$branchName" > "./data/branch_name.txt"
+else
+	exit 1
+fi

--- a/scripts/version_logger.sh
+++ b/scripts/version_logger.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Get branch names and commits
+stable=$(git rev-list --format=%s --max-count=1 stable 2>/dev/null)
+hasStable=$?
+master=$(git rev-list --format=%s --max-count=1 master 2>/dev/null)
+hasMaster=$?
+
+if [ "$hasStable" == 0 ]; then
+  echo "$stable" > "./data/stable_version.txt"
+fi
+if [ "$hasMaster" == 0 ]; then
+  echo "$master" > "./data/master_version.txt"
+fi
+
+currentName=$(git rev-parse --abbrev-ref HEAD)
+if [ "$currentName" == "master" ]; then
+  exit 0
+fi
+if [ "$currentName" == "stable" ]; then
+  exit 0
+fi
+
+currentInfo=$(git rev-list --format=%s --max-count=1 "$currentName" 2>/dev/null)
+echo "$currentInfo" > "./data/""$currentName""_version.txt"

--- a/src/main/java/bot/ESBot.java
+++ b/src/main/java/bot/ESBot.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.core.exceptions.RateLimitedException;
 
 public class ESBot {
 	private JDA jda;
+	public VersionInfo version = new VersionInfo();
 
 	// Set global URL paths for use by commands.
 	public static final String HOST_RAW_URL = "https://raw.githubusercontent.com/MCOfficer/EndlessSky-Discord-Bot/master";

--- a/src/main/java/bot/InfoCommands.java
+++ b/src/main/java/bot/InfoCommands.java
@@ -79,11 +79,25 @@ implements CommandExecutor{
 	@Command(aliases = {"-info"}, description = "Shows some information about the bot.", usage = "-info")
 	public void onInfoCommand(Guild guild, MessageChannel channel){
 		EmbedBuilder eb = new EmbedBuilder();
-		eb.setTitle("EndlessSky-Discord-Bot", bot.HOST_PUBLIC_URL);
+		eb.setTitle("**EndlessSky-Discord-Bot**", bot.HOST_PUBLIC_URL);
+		String issues = bot.HOST_PUBLIC_URL + "/issues";
 		String description =
 				"- **Author:** Maximilian Korber\n" +
 				"- **Language:** Java\n" +
-				"- **Utilized Libraries:** JDA3,lavaplayer & sdcf4j";
+				"- **Utilized Libraries:** JDA3, lavaplayer, & sdcf4j\n" +
+				"- **Maintainers:** M\\*C\\*O, tehhowch\n\n" +
+				"**Version Information:**\n";
+		if(bot.version.hasCommitInfo()){
+			description += "- **Branch:** " + bot.version.getBranch() +
+						" @[" + bot.version.getCommitHash() + "](" +
+						bot.HOST_PUBLIC_URL + "/commit/" +
+						bot.version.getCommitHash() + ")\n" +
+				"- **Commit:** " + bot.version.getCommitMessage() + "\n\n";
+		}
+		else{
+			description += "- **Branch:** " + bot.version.getBranch() + "\n\n";
+		}
+		description += "[View known issues and feature requests](" + issues + ")";
 		eb.setDescription(description);
 		eb.setColor(guild.getMember(bot.getSelf()).getColor());
 		eb.setThumbnail(bot.HOST_RAW_URL + "/thumbnails/info.png");

--- a/src/main/java/bot/LookupCommands.java
+++ b/src/main/java/bot/LookupCommands.java
@@ -27,7 +27,7 @@ implements CommandExecutor{
 
 
 
-	public String readData(){
+	private String readData(){
 		String data = "";
 		try{
 			LinkedList<URL> dataFiles = new LinkedList<>();
@@ -235,7 +235,7 @@ implements CommandExecutor{
 	// Convert the requested lookup parameter into the relevant data
 	// from the Endless Sky GitHub repository.
 	// Returns nullstring if no data could be found.
-	public String lookupData(String lookup){
+	private String lookupData(String lookup){
 		lookup = checkLookup(lookup, true);
 		if(lookup.length() > 0){
 			int start = data.indexOf(lookup);
@@ -255,7 +255,7 @@ implements CommandExecutor{
 	// Queries the loaded datafiles for special Endless Sky keywords.
 	// If helper is 'true', will try both as-passed 'lookup', and with
 	// enforced word capitalization.
-	public String checkLookup(String lookup, boolean helper){
+	private String checkLookup(String lookup, boolean helper){
 		if(data.contains("\nship \"" + lookup + "\"")){
 			return "\nship \"" + lookup + "\"";
 		}
@@ -302,7 +302,7 @@ implements CommandExecutor{
 
 	// Send the message 'output' to the desired channel, cutting into
 	// multiple messages as needed.
-	public void OutputHelper(MessageChannel channel, String output){
+	private void OutputHelper(MessageChannel channel, String output){
 		if(output.length() < 1993){
 			channel.sendMessage(":\n```" + output + "```").queue();
 		}
@@ -355,7 +355,7 @@ implements CommandExecutor{
 	// appropriate file ending for the given file. Assumes all image files
 	// are .png. Returns nullstring "" if no ending works, otherwise returns
 	// the full ending (including the filetype).
-	public String GetImageEnding(String url){
+	private String GetImageEnding(String url){
 		String[] endings = {"", "-0", "+0", "~0", "=0"};
 		int index = 0;
 		boolean hasEnding = isImage(url + endings[index] + ".png?raw=true");

--- a/src/main/java/bot/VersionInfo.java
+++ b/src/main/java/bot/VersionInfo.java
@@ -1,0 +1,68 @@
+package bot;
+
+import java.io.BufferedReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.io.IOException;
+
+
+public class VersionInfo {
+	private String hash;
+	private String msg;
+	private String branch;
+
+	// Constructor
+	VersionInfo(){
+		loadVersionInfo();
+	}
+
+
+	// Read data from the files in the ./data directory.
+	private void loadVersionInfo(){
+		try{
+			Path path = Paths.get("./data/branch_name.txt");
+			BufferedReader br = Files.newBufferedReader(path);
+			this.branch = br.readLine();
+			br.close();
+		}
+		catch(IOException x){
+			this.branch = "Unknown";
+		}
+		try{
+			Path path = Paths.get("./data/" + branch + "_version.txt");
+			BufferedReader br = Files.newBufferedReader(path);
+			this.hash = br.readLine().substring(7, 14);
+			this.msg = br.readLine();
+			br.close();
+		}
+		catch(IOException x){
+			x.printStackTrace();
+			this.hash = "unknown";
+			this.msg = "unknown";
+		}
+	}
+
+
+
+	public boolean hasCommitInfo(){
+		return !this.hash.equals("unknown");
+	}
+
+
+	public String getCommitHash(){
+		return this.hash;
+	}
+
+
+
+	public String getCommitMessage(){
+		return this.msg;
+	}
+
+
+
+	public String getBranch(){
+		return this.branch;
+	}
+}


### PR DESCRIPTION
Added class to handle bot version information
 - If on `master` or `stable`, will link to a commit hash on MCO's repo
 - Will output the title of the latest commit.
Privatise unnecessarily public functions in LookupCommands.
Add scripts to write the branch name and the most recent commit hash to file.
Update run script to require successfully writing branch, file info
Update run script to require successfully updating the dataFileNames.txt
Lightly edited the readme.