### PR TITLE
Extend capitalization to after dashes

### DIFF
--- a/src/main/java/bot/LookupCommands.java
+++ b/src/main/java/bot/LookupCommands.java
@@ -410,20 +410,36 @@ implements CommandExecutor{
 
 
 
-	// Check the string for a space character and if present, capitalize the
-	// next letter. Returns the string with first letters of words capitalized.
+	// Check the string for a space or dash character and if present,
+	// capitalize the next letter. Returns the string with captialized words.
 	private static String CapitalizeWords(String input){
-		int countWords = 1 + CountOf(input, ' ');
+		int countWords = 1 + CountOf(input, ' ') + CountOf(input, '-');
 		char[] ic = input.toCharArray();
 		ic[0] = Character.toUpperCase(ic[0]);
-		if(countWords > 1){
+		boolean hasDash = input.indexOf("-") > -1;
+		boolean hasSpace = input.indexOf(" ") > -1;
+		if(--countWords > 0){
 			int index = input.indexOf(" ");
+			if(hasDash)
+				index = Math.min(index, input.indexOf("-"));
 			for(int i = 0; i < countWords; ++i){
 				++index;
-				if(ic[index] == '(' || ic[index] == ')' || ic[index] == '"')
+				if(ic[index] == '(' || ic[index] == ')' || ic[index] == '"' || ic[index] == '-')
 					++index;
 				ic[index] = Character.toUpperCase(ic[index]);
-				index = input.indexOf(" ", index);
+				// Find next word break.
+				int s = input.indexOf(" ", index);
+				int d = input.indexOf("-", index);
+				hasDash &= d > -1;
+				hasSpace &= s > -1;
+				if(hasDash && hasSpace)
+					index = (s < d) ? s : d;
+				else if(hasDash)
+					index = d;
+				else if(hasSpace)
+					index = s;
+				else
+					break;
 			}
 		}
 


### PR DESCRIPTION
Apostrophes don't make sense - "Kor Ak'Mari" is the only instance (see all the Wanderer systems where they do not capitalize after apostrophes).

`-command korath fire-lance` will now work :)
`-command hai-home` still works

A phrase that is only two words, both capitalized, with no spaces will fail the lookup. this is intentional so that hai-home and other two words with no spaces do not fail the lookup (hai-home would become Hai-Home, which fails to match, if the starting index is properly set to the minimum value of the separators which are present in the string, e.g.
```
int index = input.length();
if(hasSpace)
    index = input.indexOf(" ");
if(hasDash)
    index = Math.min(index, input.indexOf("-"));
```
If we use that above bit, we'd need a third check for partial string capitalization