### PR TITLE
Deregister old event listeners if making new ones

### DIFF
--- a/src/main/java/bot/ESBot.java
+++ b/src/main/java/bot/ESBot.java
@@ -21,7 +21,7 @@ public class ESBot {
 	public static final String HOST_RAW_URL = "https://raw.githubusercontent.com/MCOfficer/EndlessSky-Discord-Bot/master";
 	public static final String HOST_PUBLIC_URL = "https://github.com/MCOfficer/EndlessSky-Discord-Bot";
 	public static final String CONTENT_URL = "https://github.com/endless-sky/endless-sky/raw/master";
-	public static  final String DATA_URL = "https://raw.githubusercontent.com/endless-sky/endless-sky/master/data/";
+	public static final String DATA_URL = "https://raw.githubusercontent.com/endless-sky/endless-sky/master/data/";
 
 
 	public Properties keys;
@@ -52,10 +52,11 @@ public class ESBot {
 
 
 	/**
-	 * Shutters the existing data structures, then re-loads everything.
+	 * Removes any existing event listeners, then re-loads everything.
 	 * Does not refresh the known filename lists.
 	 */
 	public synchronized void update(){
+		jda.getRegisteredListeners().forEach(jda::removeEventListener);
 		CommandHandler cmdHandler = new JDA3Handler(jda);
 		cmdHandler.registerCommand(new LookupCommands(this));
 		cmdHandler.registerCommand(new PlayerControl(this, jda));


### PR DESCRIPTION
Compiles. Didn't test it. The test would be to tell it to `-update` and then see if there are "two" James responding to things like spellerrors, `-lookup`, etc.