### PR TITLE
mortgage and navy license

### DIFF
--- a/data/spellErrors.txt
+++ b/data/spellErrors.txt
@@ -19,3 +19,6 @@ Sayrd:Saryd*
 Sadry:Saryd*
 Kimik:Kimek*
 Kimke:Kimek*
+morgage:Mortgage*
+Mortgage*:It's a crime how much interest the banks charge to first-timers
+navy license: @Kiko#0822 says, "IT'S BEING WORKED ON, OK?"

--- a/data/spellErrors.txt
+++ b/data/spellErrors.txt
@@ -21,4 +21,4 @@ Kimik:Kimek*
 Kimke:Kimek*
 morgage:Mortgage*
 Mortgage*:It's a crime how much interest the banks charge to first-timers
-navy license: @Kiko#0822 says, "IT'S BEING WORKED ON, OK?"
+navy license: @251148565479555072 says, "IT'S BEING WORKED ON, OK?"

--- a/data/spellErrors.txt
+++ b/data/spellErrors.txt
@@ -21,4 +21,4 @@ Kimik:Kimek*
 Kimke:Kimek*
 morgage:Mortgage*
 Mortgage*:It's a crime how much interest the banks charge to first-timers
-navy license: @251148565479555072 says, "IT'S BEING WORKED ON, OK?"
+navy license: <@251148565479555072> says, "IT'S BEING WORKED ON, OK?"


### PR DESCRIPTION
Misspellings of mortgage, response to it's own correction for a semi-interactive meme, temporary inclusion of navy license to ping myself for tallies and to just pester me into getting the RNS done.