### PR TITLE
Fixed max page number reporting for queues with a length that is a multiple of 10

### DIFF
--- a/src/main/java/bot/PlayerControl.java
+++ b/src/main/java/bot/PlayerControl.java
@@ -249,7 +249,7 @@ implements CommandExecutor{
 						}
 						++queuePos;
 					}
-					sb.append("\n").append("Showing Page " + ((showFrom - 1) / 10 + 1) + "/" + ((qsize - (qsize % 10)) / 10 + 1)
+					sb.append("\n").append("Showing Page " + ((showFrom - 1) / 10 + 1) + "/" + (qsize / 10 + ((qsize % 10) & 1))
 							+ ", Tracks " + (showFrom) + " - " + countMax + "/" + qsize + ".");
 					sb.append("\n").append("Total Queue Time Length: ").append(getTimestamp(queueLength));
 				}


### PR DESCRIPTION
Converted from the old method: `((qsize - (qsize % 10)) / 10 + 1)`,
to: `(qsize / 10 + ((qsize % 10) & 1))`.
`qsize /10` - integer division. Returns the number of whole pages.
`qsize % 10` - returns the number of left over tracks that do not complete a whole page.
`& 1` - bitwise AND. If the number of remaining tracks is non-zero, the max page number will be increased by 1 to account for the partially filled page.